### PR TITLE
Async Extensions

### DIFF
--- a/src/OnionSeed.Helpers.Async/AsyncExtensions.cs
+++ b/src/OnionSeed.Helpers.Async/AsyncExtensions.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OnionSeed.Helpers.Async
+{
+	/// <summary>
+	/// Contains extension methods for asynchronous operations.
+	/// </summary>
+	[SuppressMessage("Reliability", "CA2008:Do not create tasks without passing a TaskScheduler", Justification = "The scheduler is defined statically.")]
+	public static class AsyncExtensions
+	{
+		private static readonly TaskFactory SyncTaskFactory = new TaskFactory(
+			CancellationToken.None,
+			TaskCreationOptions.None,
+			TaskContinuationOptions.None,
+			TaskScheduler.Default);
+
+		/// <summary>
+		/// Runs the given async method synchronously on the default <see cref="TaskScheduler"/>.
+		/// </summary>
+		/// <param name="method">The async method to be run.</param>
+		public static void RunSynchronously(this Func<Task> method) => SyncTaskFactory
+			.StartNew(method)
+			.Unwrap()
+			.GetAwaiter()
+			.GetResult();
+
+		/// <summary>
+		/// Runs the given async method synchronously on the default <see cref="TaskScheduler"/>
+		/// and returns the result.
+		/// </summary>
+		/// <typeparam name="TResult">The type of the return value of the async method.</typeparam>
+		/// <param name="method">The async method to be run.</param>
+		/// <returns>The result of executing the given async function.</returns>
+		public static TResult RunSynchronously<TResult>(this Func<Task<TResult>> method) => SyncTaskFactory
+			.StartNew(method)
+			.Unwrap()
+			.GetAwaiter()
+			.GetResult();
+	}
+}

--- a/src/OnionSeed.Helpers.Async/OnionSeed.Helpers.Async.csproj
+++ b/src/OnionSeed.Helpers.Async/OnionSeed.Helpers.Async.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net452</TargetFramework>
+		<TargetFrameworks>net452;netstandard1.1</TargetFrameworks>
 		<Description>Helpers for async functionality.</Description>
 		<RepositoryUrl>https://github.com/TaffarelJr/OnionSeed.Helpers.Async.git</RepositoryUrl>
 	</PropertyGroup>

--- a/src/OnionSeed.Helpers.Async/OnionSeed.Helpers.Async.xml
+++ b/src/OnionSeed.Helpers.Async/OnionSeed.Helpers.Async.xml
@@ -4,6 +4,26 @@
         <name>OnionSeed.Helpers.Async</name>
     </assembly>
     <members>
+        <member name="T:OnionSeed.Helpers.Async.AsyncExtensions">
+            <summary>
+            Contains extension methods for asynchronous operations.
+            </summary>
+        </member>
+        <member name="M:OnionSeed.Helpers.Async.AsyncExtensions.RunSynchronously(System.Func{System.Threading.Tasks.Task})">
+            <summary>
+            Runs the given async method synchronously on the default <see cref="T:System.Threading.Tasks.TaskScheduler"/>.
+            </summary>
+            <param name="method">The async method to be run.</param>
+        </member>
+        <member name="M:OnionSeed.Helpers.Async.AsyncExtensions.RunSynchronously``1(System.Func{System.Threading.Tasks.Task{``0}})">
+            <summary>
+            Runs the given async method synchronously on the default <see cref="T:System.Threading.Tasks.TaskScheduler"/>
+            and returns the result.
+            </summary>
+            <typeparam name="TResult">The type of the return value of the async method.</typeparam>
+            <param name="method">The async method to be run.</param>
+            <returns>The result of executing the given async function.</returns>
+        </member>
         <member name="T:OnionSeed.Helpers.Async.TaskHelpers">
             <summary>
             Contains static helpers for <see cref="T:System.Threading.Tasks.Task"/>.

--- a/src/OnionSeed.Helpers.Async/TaskHelpers.cs
+++ b/src/OnionSeed.Helpers.Async/TaskHelpers.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if NET452
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 
@@ -40,3 +41,4 @@ namespace OnionSeed.Helpers.Async
 		}
 	}
 }
+#endif

--- a/test/OnionSeed.Helpers.Async.Tests/AsyncExtensionsTests.cs
+++ b/test/OnionSeed.Helpers.Async.Tests/AsyncExtensionsTests.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace OnionSeed.Helpers.Async
+{
+	public class AsyncExtensionsTests
+	{
+		[Fact]
+		public void RunSynchronously_ShouldExecuteAsyncMethod()
+		{
+			// Arrange
+			var called = false;
+
+			Func<Task> subject = () =>
+			{
+				called = true;
+				return Task.Delay(30);
+			};
+
+			// Act
+			subject.RunSynchronously();
+
+			// Assert
+			called.Should().BeTrue();
+		}
+
+		[Fact]
+		public void RunSynchronously_ShouldExecuteAsyncMethod_AndReturnResult()
+		{
+			// Arrange
+			const int expected = 21;
+
+			Func<Task<int>> subject = () =>
+			{
+				return Task.Delay(30)
+					.ContinueWith(t => expected, TaskScheduler.Current);
+			};
+
+			// Act
+			var result = subject.RunSynchronously();
+
+			// Assert
+			result.Should().Be(expected);
+		}
+	}
+}

--- a/test/OnionSeed.Helpers.Async.Tests/OnionSeed.Helpers.Async.Tests.csproj
+++ b/test/OnionSeed.Helpers.Async.Tests/OnionSeed.Helpers.Async.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net452</TargetFramework>
+		<TargetFrameworks>net452;net46;net461;net462;net47;net471;net472;netcoreapp1.0;netcoreapp1.1;netcoreapp2.0;netcoreapp2.1;netcoreapp2.2</TargetFrameworks>
 		<RootNamespace>OnionSeed.Helpers.Async</RootNamespace>
 	</PropertyGroup>
 

--- a/test/OnionSeed.Helpers.Async.Tests/TaskHelpersTests.cs
+++ b/test/OnionSeed.Helpers.Async.Tests/TaskHelpersTests.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if NET452
+using System;
 using FluentAssertions;
 using Xunit;
 
@@ -82,3 +83,4 @@ namespace OnionSeed.Helpers.Async
 		}
 	}
 }
+#endif


### PR DESCRIPTION
Add extension methods to be able to easily run async synchronously.

This will also necessitate expanding the target frameworks. The current `TaskHelpers` are only applicable to .NET Framework 4.5.2; these new extensions would be applicable to all currently supported target frameworks.