### PR TITLE
Helper

### DIFF
--- a/src/OnionSeed.Helpers.Async/OnionSeed.Helpers.Async.csproj
+++ b/src/OnionSeed.Helpers.Async/OnionSeed.Helpers.Async.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net452;netstandard1.1</TargetFrameworks>
+		<TargetFrameworks>netstandard1.1;netstandard1.3</TargetFrameworks>
 		<Description>Helpers for async functionality.</Description>
 		<RepositoryUrl>https://github.com/TaffarelJr/OnionSeed.Helpers.Async.git</RepositoryUrl>
 	</PropertyGroup>

--- a/src/OnionSeed.Helpers.Async/TaskHelpers.cs
+++ b/src/OnionSeed.Helpers.Async/TaskHelpers.cs
@@ -1,5 +1,4 @@
-﻿#if NET452
-using System;
+﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 
@@ -14,7 +13,14 @@ namespace OnionSeed.Helpers.Async
 		/// <summary>
 		/// Gets a task that has already completed successfully.
 		/// </summary>
-		public static Task CompletedTask { get; } = Task.FromResult(0);
+		public static Task CompletedTask
+		{
+#if NETSTANDARD1_1
+			get => Task.FromResult(0);
+#else
+			get => Task.CompletedTask;
+#endif
+		}
 
 		/// <summary>Creates a <see cref="Task"/> that has completed with a specified exception.</summary>
 		/// <param name="exception">The exception with which to complete the task.</param>
@@ -32,13 +38,13 @@ namespace OnionSeed.Helpers.Async
 		/// <exception cref="ArgumentNullException"><paramref name="exception"/> is <c>null</c>.</exception>
 		public static Task<TResult> FromException<TResult>(Exception exception)
 		{
-			if (exception == null)
-				throw new ArgumentNullException(nameof(exception));
-
+#if NETSTANDARD1_1
 			var source = new TaskCompletionSource<TResult>();
 			source.SetException(exception);
 			return source.Task;
+#else
+			return Task.FromException<TResult>(exception);
+#endif
 		}
 	}
 }
-#endif

--- a/test/OnionSeed.Helpers.Async.Tests/TaskHelpersTests.cs
+++ b/test/OnionSeed.Helpers.Async.Tests/TaskHelpersTests.cs
@@ -1,5 +1,4 @@
-﻿#if NET452
-using System;
+﻿using System;
 using FluentAssertions;
 using Xunit;
 
@@ -83,4 +82,3 @@ namespace OnionSeed.Helpers.Async
 		}
 	}
 }
-#endif


### PR DESCRIPTION
Make the `TaskHelper` class available on all target frameworks, so it can make the decision of which supported code path to call.

Also, change target frameworks to .NET Standard 1.1 + 1.3.